### PR TITLE
fix: PromiseLike bug: sync with Turbowarp

### DIFF
--- a/src/compiler/jsexecute.js
+++ b/src/compiler/jsexecute.js
@@ -116,19 +116,20 @@ const waitPromise = function*(promise) {
     const thread = globalState.thread;
     let returnValue;
 
+    // enter STATUS_PROMISE_WAIT and yield
+    // this will stop script execution until the promise handlers reset the thread status
+    // because promise handlers might execute immediately, configure thread.status here
+    thread.status = 1; // STATUS_PROMISE_WAIT
+
     promise
         .then(value => {
             returnValue = value;
             thread.status = 0; // STATUS_RUNNING
-        })
-        .catch(error => {
+        }, error => {
             thread.status = 0; // STATUS_RUNNING
             globalState.log.warn('Promise rejected in compiled script:', error);
         });
 
-    // enter STATUS_PROMISE_WAIT and yield
-    // this will stop script execution until the promise handlers reset the thread status
-    thread.status = 1; // STATUS_PROMISE_WAIT
     yield;
 
     return returnValue;


### PR DESCRIPTION
Related pull request (merged): https://github.com/TurboWarp/scratch-vm/pull/185

### Resolves

https://github.com/TurboWarp/scratch-vm/issues/184

### Proposed Changes

- Fix `PromiseLike` support in `waitPromise()` function
- Fix unintended `promise.catch` usage in `waitPromise()` function

### Reason for Changes

> From https://github.com/TurboWarp/scratch-vm/issues/184:
> - Compiler's waitPromise soft-lock if promise handlers executed immediately.

### Test Coverage

[Test unit from TurboWarp](https://github.com/TurboWarp/scratch-vm/blob/develop/test/integration/tw_block_returning_promise_like.js)