### PR TITLE
fix the opcode not found bug while reloading extension's menus

### DIFF
--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -223,8 +223,9 @@ class ExtensionManager {
         }
         const extensionInstance = isConstructor(extension) ? new extension(this.runtime) : extension;
         if (loadedExtServiceName && shouldReplace) {
-            const incomingBlocks = extensionInstance.getInfo().blocks;
-            const incomingOpsSet = new Set(incomingBlocks.map(b => b.opcode));
+            const incomingBlocks = extensionInstance.getInfo().blocks;//It only gets block from extension without the menus.
+            const incomingMenus = Object.keys(extensionInstance.getInfo().menus || {});//This can get menus from extension. It's an array of menus' names.
+            const incomingOpsSet = new Set(incomingBlocks.map(b => b.opcode).concat(incomingMenus.map(m =>`menu_${m}`)));
             const opsInUseSet = new Set(this.runtime.targets
                 .map(({blocks}) => Object.values(blocks._blocks).map(b => b.opcode))
                 .flat()


### PR DESCRIPTION
### Resolves

[issue #9 ](https://github.com/Gandi-IDE/scratch-vm/issues/9)

### Proposed Changes

gets the menus from the info to avoid "opcode not found"


### Test Coverage

I tested the changes in the file and it work well.It can convert menus to opcode and concat together

Hi,bro@sylarhcn 